### PR TITLE
Fix meta spec for RSpec 3.x

### DIFF
--- a/spec/meta/deck_card_meta_spec.rb
+++ b/spec/meta/deck_card_meta_spec.rb
@@ -4,7 +4,7 @@ describe '[LAB CHECKER] Deck and Card Organization Spec Requirements' do
   files = Dir[File.expand_path('../../student/*_spec.rb', __FILE__)]
 
   it 'has at least one student spec file in spec/student/' do
-    expect(files.any?).to be true, 'Expected at least one spec file in spec/student/'
+    expect(files).not_to be_empty
   end
 
   files.each do |file|


### PR DESCRIPTION
The meta spec used expect(...).to be true, 'message', which worked in older RSpec versions but raises an ArgumentError in RSpec 3.x (rspec-expectations 3.13.5).

Updated the line to:

```expect(files).not_to be_empty```

This avoids the version conflict and keeps the same intent: ensuring at least one student spec exists in spec/student/.