### PR TITLE
Provide Unorganized Starter Specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rspec'
 require_relative '../lib/deck'
 require_relative '../lib/card'
 
@@ -7,4 +8,5 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+  Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each { |f| require f }
 end

--- a/spec/student/card_spec.rb
+++ b/spec/student/card_spec.rb
@@ -1,4 +1,3 @@
-# spec/student/card_spec.rb
 # frozen_string_literal: true
 
 require_relative '../../lib/card'

--- a/spec/student/card_spec.rb
+++ b/spec/student/card_spec.rb
@@ -1,5 +1,81 @@
+# spec/student/card_spec.rb
 # frozen_string_literal: true
 
+require_relative '../../lib/card'
+
 describe Card do
-  # ...student specs...
+  subject(:example_card) { Card.new('Hearts', '7') }
+
+  it 'stores suit on initialize' do
+    c = Card.new('Diamonds', '3')
+    expect(c.suit).to eq('Diamonds')
+  end
+
+  it 'stores rank on initialize' do
+    c = Card.new('Diamonds', '3')
+    expect(c.rank).to eq('3')
+  end
+
+  it 'raises for invalid suit' do
+    expect { Card.new('Stars', '3') }.to raise_error(ArgumentError)
+  end
+
+  it 'raises for invalid rank' do
+    expect { Card.new('Hearts', '14') }.to raise_error(ArgumentError)
+  end
+
+  it 'returns integer value for numeric rank' do
+    c = Card.new('Clubs', '8')
+    expect(c.value).to eq(8)
+  end
+
+  it 'treats "10" as 10' do
+    c = Card.new('Spades', '10')
+    expect(c.value).to eq(10)
+  end
+
+  it 'treats J as 10' do
+    c = Card.new('Clubs', 'J')
+    expect(c.value).to eq(10)
+  end
+
+  it 'treats Q as 10' do
+    c = Card.new('Hearts', 'Q')
+    expect(c.value).to eq(10)
+  end
+
+  it 'treats K as 10' do
+    c = Card.new('Diamonds', 'K')
+    expect(c.value).to eq(10)
+  end
+
+  it 'treats A as 11' do
+    c = Card.new('Spades', 'A')
+    expect(c.value).to eq(11)
+  end
+
+  it 'face_card? is false for numeric ranks' do
+    c = Card.new('Hearts', '9')
+    expect(c.face_card?).to be(false)
+  end
+
+  it 'face_card? is true for J' do
+    c = Card.new('Hearts', 'J')
+    expect(c.face_card?).to be(true)
+  end
+
+  it 'ace? is true for A' do
+    c = Card.new('Clubs', 'A')
+    expect(c.ace?).to be(true)
+  end
+
+  it 'ace? is false for non-ace' do
+    c = Card.new('Clubs', '2')
+    expect(c.ace?).to be(false)
+  end
+
+  it 'to_s formats as "<rank> of <suit>"' do
+    c = Card.new('Diamonds', 'Q')
+    expect(c.to_s).to eq('Q of Diamonds')
+  end
 end

--- a/spec/student/deck_spec.rb
+++ b/spec/student/deck_spec.rb
@@ -1,4 +1,3 @@
-# spec/student/deck_spec.rb
 # frozen_string_literal: true
 
 require_relative '../../lib/deck'

--- a/spec/student/deck_spec.rb
+++ b/spec/student/deck_spec.rb
@@ -1,5 +1,56 @@
+# spec/student/deck_spec.rb
 # frozen_string_literal: true
 
+require_relative '../../lib/deck'
+require_relative '../../lib/card'
+
 describe Deck do
-  # ...student specs...
+  subject(:deck) { Deck.new }
+
+  it 'starts with 52 cards' do
+    d = Deck.new
+    expect(d.size).to eq(52)
+  end
+
+  it 'contains only Card instances' do
+    d = Deck.new
+    expect(d.cards.all? { |c| c.is_a?(Card) }).to be(true)
+  end
+
+  it 'is not empty on creation' do
+    d = Deck.new
+    expect(d.empty?).to be(false)
+  end
+
+  it 'shuffle! does not change the number of cards' do
+    d = Deck.new
+    count = d.size
+    d.shuffle!
+    expect(d.size).to eq(count)
+  end
+
+  it 'draw returns a Card' do
+    d = Deck.new
+    c = d.draw
+    expect(c).to be_a(Card)
+  end
+
+  it 'draw reduces the size by one' do
+    d = Deck.new
+    before = d.size
+    d.draw
+    expect(d.size).to eq(before - 1)
+  end
+
+  it 'empty? becomes true after drawing all cards' do
+    d = Deck.new
+    52.times { d.draw }
+    expect(d.empty?).to be(true)
+  end
+
+  it 'empty? is false when cards remain' do
+    d = Deck.new
+    51.times { d.draw }
+    expect(d.empty?).to be(false)
+  end
 end


### PR DESCRIPTION
Providing unorganized starter specs for future PCA students per lab instructions:

"Open the specs for Deck and Card in spec/student/ and organize them for clarity and maintainability.

    Look for repeated setup, similar expectations, or repeated Deck/Card objects—these are good candidates for subject, let, or shared examples.
    "Refactor the specs" means: group related tests, use context for different Deck/Card scenarios, and use shared examples to avoid duplication."